### PR TITLE
config: fix typo on configuration variable

### DIFF
--- a/invenio_s3/config.py
+++ b/invenio_s3/config.py
@@ -19,7 +19,7 @@ If set to a value (including the "http/https" scheme) it will be passed as
 <https://boto3.readthedocs.io/en/latest/reference/core/session.html#boto3.session.Session.client>`_.
 """
 
-S3_ACCCESS_KEY_ID = None
+S3_ACCESS_KEY_ID = None
 """The access key to use when creating the client.
 
 This is entirely optional, and if not provided, the credentials configured for
@@ -29,7 +29,7 @@ See `Configuring Credentials
 for more information.
 """
 
-S3_SECRECT_ACCESS_KEY = None
+S3_SECRET_ACCESS_KEY = None
 """The secret key to use when creating the client.
 
 This is entirely optional, and if not provided, the credentials configured for

--- a/invenio_s3/ext.py
+++ b/invenio_s3/ext.py
@@ -8,6 +8,8 @@
 
 from __future__ import absolute_import, print_function
 
+import warnings
+
 import boto3
 from flask import current_app
 from werkzeug.utils import cached_property
@@ -26,9 +28,29 @@ class InvenioS3(object):
     @cached_property
     def init_s3f3_info(self):
         """Gather all the information needed to start the S3FSFileSystem."""
+        if 'S3_ACCCESS_KEY_ID' in current_app.config:
+            current_app.config['S3_ACCESS_KEY_ID'] = current_app.config[
+                'S3_ACCCESS_KEY_ID']
+            warnings.warn(
+                'Key S3_ACCCESS_KEY_ID contained a typo and has been '
+                'corrected to S3_ACCESS_KEY_ID, support for the '
+                'flawed version will be removed.',
+                DeprecationWarning
+            )
+
+        if 'S3_SECRECT_ACCESS_KEY' in current_app.config:
+            current_app.config['S3_SECRET_ACCESS_KEY'] = current_app.config[
+                'S3_SECRECT_ACCESS_KEY']
+            warnings.warn(
+                'Key S3_SECRECT_ACCESS_KEY contained a typo and has been '
+                'corrected to S3_SECRET_ACCESS_KEY, support for the '
+                'flawed version will be removed.',
+                DeprecationWarning
+            )
+
         info = dict(
-            key=current_app.config.get('S3_ACCCESS_KEY_ID', ''),
-            secret=current_app.config.get('S3_SECRECT_ACCESS_KEY', ''),
+            key=current_app.config.get('S3_ACCESS_KEY_ID', ''),
+            secret=current_app.config.get('S3_SECRET_ACCESS_KEY', ''),
             client_kwargs={},
             config_kwargs={
                 's3': {

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup_requires = [
 install_requires = [
     'boto3>=1.9.83',
     'invenio-files-rest>=1.0.0a23',
-    's3fs>=0.1.5',
+    's3fs>=0.1.5,<0.3.0', # Newer versions only allow python >= 3.5
 ]
 
 packages = find_packages()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ def app_config(app_config):
     app_config[
         'FILES_REST_STORAGE_FACTORY'] = 'invenio_s3.s3fs_storage_factory'
     app_config['S3_ENDPOINT_URL'] = None
-    app_config['S3_ACCCESS_KEY_ID'] = 'test'
+    app_config['S3_ACCESS_KEY_ID'] = 'test'
     app_config['S3_SECRECT_ACCESS_KEY'] = 'test'
     return app_config
 
@@ -42,7 +42,7 @@ def s3_bucket(appctx):
     """S3 bucket fixture."""
     with mock_s3():
         session = boto3.Session(
-            aws_access_key_id=current_app.config.get('S3_ACCCESS_KEY_ID'),
+            aws_access_key_id=current_app.config.get('S3_ACCESS_KEY_ID'),
             aws_secret_access_key=current_app.config.get(
                 'S3_SECRECT_ACCESS_KEY'),
         )

--- a/tests/test_invenio_s3.py
+++ b/tests/test_invenio_s3.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2018 Esteban J. G. Gabancho.
+# Copyright (C) 2018, 2019 Esteban J. G. Gabancho.
 #
 # Invenio-S3 is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -17,12 +17,35 @@ def test_version():
     assert __version__
 
 
-def test_init(base_app):
+def test_init(appctx):
     """Test extension initialization."""
-    assert 'invenio-s3' in base_app.extensions
+    assert 'invenio-s3' in appctx.extensions
 
-    with base_app.app_context():
-        base_app.config['S3_ENDPOINT_URL'] = 'https://example.com:1234'
-        s3_connection_info = base_app.extensions['invenio-s3'].init_s3f3_info
-        assert s3_connection_info['client_kwargs'][
-            'endpoint_url'] == 'https://example.com:1234'
+    appctx.config['S3_ENDPOINT_URL'] = 'https://example.com:1234'
+    s3_connection_info = appctx.extensions['invenio-s3'].init_s3f3_info
+    assert s3_connection_info['client_kwargs'][
+        'endpoint_url'] == 'https://example.com:1234'
+
+
+def test_access_key(appctx):
+    """Test correct access key works together with flawed one."""
+    appctx.config['S3_ACCCESS_KEY_ID'] = 'secret'
+    try:
+        # Delete the cached value in case it's there already
+        del appctx.extensions['invenio-s3'].__dict__['init_s3f3_info']
+    except KeyError:
+        pass
+    s3_connection_info = appctx.extensions['invenio-s3'].init_s3f3_info
+    assert s3_connection_info['key'] == 'secret'
+
+
+def test_secret_key(appctx):
+    """Test correct secret key works together with flawed one."""
+    appctx.config['S3_SECRECT_ACCESS_KEY'] = 'secret'
+    try:
+        # Delete the cached value in case it's there already
+        del appctx.extensions['invenio-s3'].__dict__['init_s3f3_info']
+    except KeyError:
+        pass
+    s3_connection_info = appctx.extensions['invenio-s3'].init_s3f3_info
+    assert s3_connection_info['secret'] == 'secret'


### PR DESCRIPTION
* Fix typo on `S3_ACCCESS_KEY_ID`, (too many Cs) and add a deprecation
  warning for the old key. (closes #3)