### PR TITLE
installation: set upper bound for s3fs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup_requires = [
 install_requires = [
     'boto3>=1.9.83',
     'invenio-files-rest>=1.0.0a23',
-    's3fs>=0.1.5',
+    's3fs>=0.1.5,<0.3.0', # Newer versions only allow python >= 3.5
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* Newer versions of s3fs (> 0.3.0) only support python >= 3.5