### PR TITLE
storage: calculate block size for multipart upload

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@
 Changes
 =======
 
+Version 1.0.3 (released 2020-04-25)
+
+- Allow for dynamic part size for multipart uploads.
+- Adds new configuration variables to define default part size and maximum
+  number of parts.
+
 Version 1.0.2 (released 2020-02-17)
 
 - Fixes typos on configuration variables and cached properties.

--- a/invenio_s3/config.py
+++ b/invenio_s3/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2018, 2019 Esteban J. G. Gabancho.
+# Copyright (C) 2018, 2019, 2020 Esteban J. G. Gabancho.
 #
 # Invenio-S3 is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -63,3 +63,14 @@ See `Amazon Boto3 documentation on configuration variables
 <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuration-file>`_
 for more information.
 """
+
+S3_MAXIMUM_NUMBER_OF_PARTS = 10000
+"""Maximum number of parts to be used.
+See `AWS Multipart Upload Overview
+<https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html>`_ for more
+information.
+"""
+
+S3_DEFAULT_BLOCK_SIZE = 5 * 2**20
+"""Default block size value used to send multi-part uploads to S3.
+Typically 5Mb is minimum allowed by the API."""

--- a/invenio_s3/storage.py
+++ b/invenio_s3/storage.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2018, 2019 Esteban J. G. Gabancho.
+# Copyright (C) 2018, 2019, 2020 Esteban J. G. Gabancho.
 #
 # Invenio-S3 is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 """S3 file storage interface."""
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, division, print_function
 
-from functools import partial
+from functools import partial, wraps
 
 import s3fs
 from flask import current_app
@@ -17,11 +17,30 @@ from invenio_files_rest.storage import PyFSFileStorage, pyfs_storage_factory
 from .helpers import redirect_stream
 
 
+def set_blocksize(f):
+    """Decorator to set the correct block size according to file size."""
+    @wraps(f)
+    def inner(self, *args, **kwargs):
+        size = kwargs.get('size', None)
+        block_size = (
+            size // current_app.config['S3_MAXIMUM_NUMBER_OF_PARTS']  # Integer
+            if size
+            else current_app.config['S3_DEFAULT_BLOCK_SIZE']
+        )
+
+        if block_size > self.block_size:
+            self.block_size = block_size
+        return f(self, *args, **kwargs)
+
+    return inner
+
+
 class S3FSFileStorage(PyFSFileStorage):
     """File system storage using Amazon S3 API for accessing files."""
 
     def __init__(self, fileurl, **kwargs):
         """Storage initialization."""
+        self.block_size = current_app.config['S3_DEFAULT_BLOCK_SIZE']
         super(S3FSFileStorage, self).__init__(fileurl, **kwargs)
 
     def _get_fs(self, *args, **kwargs):
@@ -30,10 +49,11 @@ class S3FSFileStorage(PyFSFileStorage):
             return super(S3FSFileStorage, self)._get_fs(*args, **kwargs)
 
         info = current_app.extensions['invenio-s3'].init_s3fs_info
-        fs = s3fs.S3FileSystem(**info)
+        fs = s3fs.S3FileSystem(default_block_size=self.block_size, **info)
 
         return (fs, self.fileurl)
 
+    @set_blocksize
     def initialize(self, size=0):
         """Initialize file on storage and truncate to given size."""
         fs, path = self._get_fs()
@@ -46,8 +66,9 @@ class S3FSFileStorage(PyFSFileStorage):
             to_write = size
             fs_chunk_size = fp.blocksize  # Force write every time
             while to_write > 0:
-                current_chunk_size = (to_write if to_write <= fs_chunk_size
-                                      else fs_chunk_size)
+                current_chunk_size = (
+                    to_write if to_write <= fs_chunk_size else fs_chunk_size
+                )
                 fp.write(b'\0' * current_chunk_size)
                 to_write -= current_chunk_size
         except Exception:
@@ -68,23 +89,30 @@ class S3FSFileStorage(PyFSFileStorage):
             fs.rm(path)
         return True
 
-    def update(self,
-               incoming_stream,
-               seek=0,
-               size=None,
-               chunk_size=None,
-               progress_callback=None):
+    @set_blocksize
+    def update(
+        self,
+        incoming_stream,
+        seek=0,
+        size=None,
+        chunk_size=None,
+        progress_callback=None,
+    ):
         """Update a file in the file system."""
         old_fp = self.open(mode='rb')
-        updated_fp = S3FSFileStorage(
-            self.fileurl, size=self._size).open(mode='wb')
+        updated_fp = S3FSFileStorage(self.fileurl, size=self._size).open(
+            mode='wb'
+        )
         try:
             if seek >= 0:
                 to_write = seek
                 fs_chunk_size = updated_fp.blocksize
                 while to_write > 0:
-                    current_chunk_size = (to_write if to_write <= fs_chunk_size
-                                          else fs_chunk_size)
+                    current_chunk_size = (
+                        to_write
+                        if to_write <= fs_chunk_size
+                        else fs_chunk_size
+                    )
                     updated_fp.write(old_fp.read(current_chunk_size))
                     to_write -= current_chunk_size
 
@@ -93,15 +121,19 @@ class S3FSFileStorage(PyFSFileStorage):
                 updated_fp,
                 chunk_size=chunk_size,
                 size=size,
-                progress_callback=progress_callback)
+                progress_callback=progress_callback,
+            )
 
             if (bytes_written + seek) < self._size:
                 old_fp.seek((bytes_written + seek))
                 to_write = self._size - (bytes_written + seek)
                 fs_chunk_size = updated_fp.blocksize
                 while to_write > 0:
-                    current_chunk_size = (to_write if to_write <= fs_chunk_size
-                                          else fs_chunk_size)
+                    current_chunk_size = (
+                        to_write
+                        if to_write <= fs_chunk_size
+                        else fs_chunk_size
+                    )
                     updated_fp.write(old_fp.read(current_chunk_size))
                     to_write -= current_chunk_size
         finally:
@@ -110,19 +142,22 @@ class S3FSFileStorage(PyFSFileStorage):
 
         return bytes_written, checksum
 
-    def send_file(self,
-                  filename,
-                  mimetype=None,
-                  restricted=True,
-                  checksum=None,
-                  trusted=False,
-                  chunk_size=None,
-                  as_attachment=False):
+    def send_file(
+        self,
+        filename,
+        mimetype=None,
+        restricted=True,
+        checksum=None,
+        trusted=False,
+        chunk_size=None,
+        as_attachment=False,
+    ):
         """Send the file to the client."""
         try:
             fs, path = self._get_fs()
             s3_url_builder = partial(
-                fs.url, path, expires=current_app.config['S3_URL_EXPIRATION'])
+                fs.url, path, expires=current_app.config['S3_URL_EXPIRATION']
+            )
 
             return redirect_stream(
                 s3_url_builder,
@@ -135,6 +170,7 @@ class S3FSFileStorage(PyFSFileStorage):
         except Exception as e:
             raise StorageError('Could not send file: {}'.format(e))
 
+    @set_blocksize
     def copy(self, src, *args, **kwargs):
         """Copy data from another file instance.
 
@@ -146,6 +182,14 @@ class S3FSFileStorage(PyFSFileStorage):
             fs.copy(src.fileurl, path)
         else:
             super(S3FSFileStorage, self).copy(src, *args, **kwargs)
+
+    @set_blocksize
+    def save(self, *args, **kwargs):
+        """Save incoming stream to storage.
+
+        Just overwrite parent method to allow set the correct block size.
+        """
+        return super(S3FSFileStorage, self).save(*args, **kwargs)
 
 
 def s3fs_storage_factory(**kwargs):

--- a/invenio_s3/version.py
+++ b/invenio_s3/version.py
@@ -13,4 +13,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'

--- a/setup.py
+++ b/setup.py
@@ -16,23 +16,23 @@ history = open('CHANGES.rst').read()
 tests_require = [
     'check-manifest>=0.25',
     'coverage>=5.0',
-    'invenio-base>=1.2.0',
-    'invenio-app>=1.2.0',
-    'invenio-db[all]>=1.0.2',
+    'invenio-base>=1.2.2',
+    'invenio-app>=1.2.3',
+    'invenio-db[all]>=1.0.4',
     'isort>=4.3.3',
     'moto>=1.3.7',
     'pydocstyle>=1.0.0',
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',
-    'pytest-invenio>=1.0.4,<1.1.0',
+    'pytest-invenio>=1.3.0',
     'pytest-pep8>=1.0.6',
-    'pytest>=3.8.0',
+    'pytest>=4.6.4,<5.0.0',
     'redis>=2.10.5',
 ]
 
 extras_require = {
     'docs': [
-        'Sphinx>=1.5.1',
+        'Sphinx>=1.5.1,<3.0.2',
     ],
     'tests': tests_require,
 }


### PR DESCRIPTION
* When the file is too big, the block size doesn't get updated and we
  reach multipart maximum number of parts raising the corresponding
  exception. Calculating the block size for each operation based on the
  actual file size seems to solve the issue. (closes #11)