### PR TITLE
fix: add cache-control for s3 presigned urls

### DIFF
--- a/invenio_s3/helpers.py
+++ b/invenio_s3/helpers.py
@@ -96,5 +96,7 @@ def redirect_stream(
         if cache_timeout is not None:
             rv.cache_control.max_age = cache_timeout
             rv.expires = int(time() + cache_timeout)
+    else:
+        rv.cache_control.no_cache = True
 
     return rv

--- a/invenio_s3/helpers.py
+++ b/invenio_s3/helpers.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2026 California Institute of Technology.
 # SPDX-FileCopyrightText: 2018, 2019 Esteban J. G. Gabancho.
 # SPDX-FileCopyrightText: 2024 Graz University of Technology.
 # SPDX-License-Identifier: MIT
@@ -6,6 +7,7 @@
 
 import mimetypes
 import unicodedata
+from time import time
 from urllib.parse import quote
 
 from flask import current_app
@@ -77,15 +79,7 @@ def redirect_stream(
     )
     headers["Location"] = url
 
-    # TODO: Set cache-control
-    # if not restricted:
-    #     rv.cache_control.public = True
-    #     cache_timeout = current_app.get_send_file_max_age(filename)
-    #     if cache_timeout is not None:
-    #         rv.cache_control.max_age = cache_timeout
-    #         rv.expires = int(time() + cache_timeout)
     # Construct response object.
-
     rv = current_app.response_class(
         url,
         status=302,
@@ -93,5 +87,14 @@ def redirect_stream(
         mimetype=mimetype,
         direct_passthrough=True,
     )
+
+    # Cache control: if the file is not restricted, we set caching to the
+    # presigned url expiration time
+    if not restricted:
+        rv.cache_control.public = True
+        cache_timeout = current_app.config["S3_URL_EXPIRATION"]
+        if cache_timeout is not None:
+            rv.cache_control.max_age = cache_timeout
+            rv.expires = int(time() + cache_timeout)
 
     return rv


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Cache-control was a TODO, and now it's not. I basically copied the logic from https://github.com/inveniosoftware/invenio-files-rest/blob/616dc34c38006433653211feb5a9e523b0d399e7/invenio_files_rest/helpers.py#L182, using the expiration time of the S3 pre-signed url. After that point the link won't work so it shouldn't be cached.

Note that this won't do anything in RDM until https://github.com/inveniosoftware/invenio-app-rdm/pull/3324 is addressed.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
